### PR TITLE
Modified Circular-Doubly-Linked-List

### DIFF
--- a/CircularDoublyLinkedList/CircularDoublyLikedList.java
+++ b/CircularDoublyLinkedList/CircularDoublyLikedList.java
@@ -99,6 +99,7 @@ public class CircularDoublyLikedList {
 
   @Override
   public String toString() {
+    if(size()==0) return "[]"
 
     String s = "[" + first.e;
     Node curr = first.next;
@@ -113,6 +114,7 @@ public class CircularDoublyLikedList {
   }
 
   public String reverse() {
+    if(size()==0) return "[]"
 
     String s = "[" + first.prev.e;
     Node curr = first.prev;
@@ -146,6 +148,12 @@ public class CircularDoublyLikedList {
     }
     return curr.e;
 
+  }
+
+  public boolean isEmpty(){
+
+    if(size()==0) return true;
+    return false;
   }
 
 }


### PR DESCRIPTION
1.toString method for a doubly circular linked list to return [] empty braces with [,] if the linked list size is empty. This is a useful modification as it provides a clearer representation of an empty linked list.[ ] empty braces

2.Additionally, you may have also implemented the reverse method for the doubly circular linked list. This is also a great modification as it allows users to reverse the order of the elements in the linked list. By swapping the next and previous pointers for each node and updating the head and tail pointers, the reverse method can efficiently reverse the linked list without requiring any additional space.
this method also previously returning [, ] so changed to []